### PR TITLE
Remove redundant `the`

### DIFF
--- a/07_resource_types_and_traits.md
+++ b/07_resource_types_and_traits.md
@@ -42,7 +42,7 @@ traits:
           required: true
 ```
 
-The following example builds on the previous one, but the the resource types and traits are defined in external files that are included by using the RAML !include data type.
+The following example builds on the previous one, but the resource types and traits are defined in external files that are included by using the RAML !include data type.
 
 ```yaml
 #%RAML 0.8


### PR DESCRIPTION
Also i have a question about the same chapter where it says in the first section:

> A trait is a partial method definition that, like a method, can provide method-level properties such as description, headers, query string parameters, and responses. _Methods that use one or more traits inherit those traits' properties._

and -  hardly two paragraphs further, in the middle of resource type explanation, it merely repeats:

> _Similarly, methods may specify one or more traits from which they inherit using the is property._

Just an observation, believe this could be streamlined somehow.