### PR TITLE
ued instead of used typo

### DIFF
--- a/raml-0.8.md
+++ b/raml-0.8.md
@@ -631,7 +631,7 @@ baseUri: https://{apiDomain}.someapi.com
 
 ```
 
-The special baseUriParameter *version* is reserved; processing applications MUST replace occurrences of {version} in any baseUri property values with the value of the root-level *version* property. The {version} parameter, if used in a baseUri, is required: if it is ued in a baseUri, the *version* root-level property MUST be provided and MUST be a valid non-empty URI fragment.
+The special baseUriParameter *version* is reserved; processing applications MUST replace occurrences of {version} in any baseUri property values with the value of the root-level *version* property. The {version} parameter, if used in a baseUri, is required: if it is used in a baseUri, the *version* root-level property MUST be provided and MUST be a valid non-empty URI fragment.
 
 #### Absolute URI
 


### PR DESCRIPTION
Just a formalism based on the simplicity of the change, but still.
