### PR TITLE
Update raml-0.8.md

### DIFF
--- a/raml-0.8.md
+++ b/raml-0.8.md
@@ -604,7 +604,7 @@ baseUri: https://{apiDomain}.someapi.com
         enum: [ "static" ]
 ```
 
-In the following example, the `PUT` method overrides the definition made in `/user/{userId}/image`.
+In the following example, the `PUT` method overrides the definition made in `/users/{userId}/image`.
 
 ```
 #%RAML 0.8


### PR DESCRIPTION
/user instead of /users typo