### PR TITLE
fixed discriminator example to use integer instead of string

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -661,11 +661,11 @@ types:
   Employee: # kind may equal to `Employee; default value for `discriminatorValue`
     type: Person
     properties:
-      employeeId: string
+      employeeId: integer
   User: # kind may equal to `User`; default value for `discriminatorValue`
     type: Person
     properties:
-      userId: string
+      userId: integer
 ```
 
 ```yaml


### PR DESCRIPTION
fixes #413 