### PR TITLE
add clarification for the enum facet and that it applies to scalar types only

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -519,7 +519,7 @@ A type declaration references another type, or wraps or extends another type by 
 | (&lt;annotationName&gt;)? | [Annotations](#annotations) to be applied to this API. An annotation is a map having a key that begins with "(" and ends with ")" where the text enclosed in parentheses is the annotation name, and the value is an instance of that annotation.
 | facets? | A map of additional, user-defined restrictions that will be inherited and applied by any extending subtype. See section [User-defined Facets](#user-defined-facets) for more information.
 | xml? | The capability to configure [XML serialization of this type instance](#xml-serialization-of-type-instances).
-| enum? | Enumeration of possible values for this built-in scalar type. The value is an array containing representations of possible values, or a single value if there is only one possible value.
+| enum? | An enumeration of all the possible values of instances of this type. The value is an array containing representations of these possible values; an instance of this type MUST be equal to one of these values.
 
 The "schema" and "type" facets are mutually exclusive and synonymous: processors MUST NOT allow both to be specified, explicitly or implicitly, inside the same type declaration. Therefore, the following examples are invalid:
 

--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -880,7 +880,7 @@ Using `Email[]` is equivalent to using `type: array`.  The `items` facet defines
 
 ### Scalar Types
 
-RAML defines a set of built-in scalar types, each of which has a predefined set of restrictions. All types, except the file type, can have an additional `enum` facet.
+RAML defines a set of built-in scalar types, each of which has a predefined set of restrictions. All scalar types, except the file type, can have an additional `enum` facet.
 
 | Facet | Description |
 |:--------|:------------|
@@ -1291,9 +1291,9 @@ Imagine a more complex example of a union type used in a multiple inheritance ty
 
 ```yaml
 types:
-   HasHome: 
+   HasHome:
      type: object
-     properties: 
+     properties:
        homeAddress: string
    Cat:
      type: object
@@ -1308,7 +1308,7 @@ types:
    HomeAnimal: [ HasHome ,  Dog | Cat ]
 ```
 
-In this case, type `HomeAnimal` has two base types, `HasHome` and an anonymous union type, defined by the following type expression: `Dog | Cat`. 
+In this case, type `HomeAnimal` has two base types, `HasHome` and an anonymous union type, defined by the following type expression: `Dog | Cat`.
 
 Validating the `HomeAnimal` type involves validating the types derived from each of the base types and the types of each element in the union type. In this particular case, you need to test that types `[HasHome, Dog]` and `[HasHome, Cat]` are valid types.
 

--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -519,6 +519,7 @@ A type declaration references another type, or wraps or extends another type by 
 | (&lt;annotationName&gt;)? | [Annotations](#annotations) to be applied to this API. An annotation is a map having a key that begins with "(" and ends with ")" where the text enclosed in parentheses is the annotation name, and the value is an instance of that annotation.
 | facets? | A map of additional, user-defined restrictions that will be inherited and applied by any extending subtype. See section [User-defined Facets](#user-defined-facets) for more information.
 | xml? | The capability to configure [XML serialization of this type instance](#xml-serialization-of-type-instances).
+| enum? | Enumeration of possible values for this built-in scalar type. The value is an array containing representations of possible values, or a single value if there is only one possible value.
 
 The "schema" and "type" facets are mutually exclusive and synonymous: processors MUST NOT allow both to be specified, explicitly or implicitly, inside the same type declaration. Therefore, the following examples are invalid:
 
@@ -880,26 +881,7 @@ Using `Email[]` is equivalent to using `type: array`.  The `items` facet defines
 
 ### Scalar Types
 
-RAML defines a set of built-in scalar types, each of which has a predefined set of restrictions. All scalar types, except the file type, can have an additional `enum` facet.
-
-| Facet | Description |
-|:--------|:------------|
-| enum? | Enumeration of possible values for this built-in scalar type. The value is an array containing representations of possible values, or a single value if there is only one possible value.
-
-Example usage of enums:
-
-```yaml
-#%RAML 1.0
-title: My API With Types
-types:
-  country:
-    type: string
-    enum: [ usa, rus ]
-
-  sizes:
-    type: number
-    enum: [ 1, 2, 3 ]
-```
+RAML defines a set of built-in scalar types, each of which has a predefined set of restrictions.
 
 #### String
 


### PR DESCRIPTION
According to #501, all types can define the `enum` facet. This PR clarifies that.