### PR TITLE
removed repeat from the list of possible scalar-valued nodes

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -2938,7 +2938,6 @@ schema
 default
 example
 usage
-repeat
 required
 content
 strict


### PR DESCRIPTION
According to #534 - `repeat` has been removed in 1.0 and should not occur in the spec anymore. This PR removes the leftovers.