### PR TITLE
removed '#%RAML 1.0' from examples where it does not belong

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -3152,7 +3152,6 @@ traits: !include patterns/traits.raml
 ```
 
 ```yaml
-#%RAML 1.0
 # This file is located at patterns/resourceTypes.raml
 
 collection:
@@ -3166,7 +3165,6 @@ member:
 ```
 
 ```yaml
-#%RAML 1.0
 # This file is located at patterns/traits.raml
 
 chargeable:


### PR DESCRIPTION
fixes #522 