### PR TITLE
changed 'null' to 'nil'

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -78,7 +78,7 @@ Throughout this specification, **Markdown** means [GitHub-Flavored Markdown](htt
 			- [Boolean](#boolean)
 			- [Date](#date)
 			- [File](#file)
-			- [Null Type](#null-type)
+			- [Nil Type](#nil-type)
 		- [Union Type](#union-type)
 		- [Using XML and JSON Schema](#using-xml-and-json-schema)
 	- [User-defined Facets](#user-defined-facets)
@@ -551,7 +551,7 @@ The RAML type system defines the following built-in types:
 * [object](#object-type)
 * [array](#array-type)
 * [union](#union-type) via type expression
-* one of the following [scalar types](#scalar-types): number, boolean, string, date-only, time-only, datetime-only, datetime, file, integer, or null
+* one of the following [scalar types](#scalar-types): number, boolean, string, date-only, time-only, datetime-only, datetime, file, integer, or nil
 
 Additional to the built-in types, the RAML type system also allows to define [JSON or XML schema](#using-xml-and-json-schema).
 
@@ -1031,15 +1031,15 @@ types:
     maxLength: 1048576
 ```
 
-##### Null Type
+##### Nil Type
 ​
-In RAML, the type `null` is a scalar type that allows only null data values. Specifically, in YAML it allows only YAML's `null` (or its equivalent representations, such as `~`), in JSON it allows only JSON's `null`, and in XML it allows only XML's `xsi:nil`. In headers, URI parameters, and query parameters, the `null` type only allows the string value "null" (case-sensitive); and in turn an instance having the string value "null" (case-sensitive), when described with the `null` type, deserializes to a null value.
+In RAML, the type `nil` is a scalar type that allows only nil data values. Specifically, in YAML it allows only YAML's `null` (or its equivalent representations, such as `~`), in JSON it allows only JSON's `null`, and in XML it allows only XML's `xsi:nil`. In headers, URI parameters, and query parameters, the `nil` type only allows the string value "nil" (case-sensitive); and in turn an instance having the string value "nil" (case-sensitive), when described with the `nil` type, deserializes to a nil value.
 
-In the following example, the type of an object and has two required properties, `name` and `comment`, both defaulting to type `string`. In `example`, `name` is assigned a string value, but comment is null and this is _not_ allowed because RAML expects a string.
+In the following example, the type of an object and has two required properties, `name` and `comment`, both defaulting to type `string`. In `example`, `name` is assigned a string value, but comment is nil and this is _not_ allowed because RAML expects a string.
 
 ```yaml
 types:
-  NullValue:
+  NilValue:
     type: object
     properties:
       name:
@@ -1049,37 +1049,37 @@ types:
       comment: # Providing no value here is not allowed.
 ```
 
-The following example shows the assignment of the `null` type to `comment`:
+The following example shows the assignment of the `nil` type to `comment`:
 
 ​
 ```yaml
 types:
-  NullValue:
+  NilValue:
     type: object
     properties:
       name:
-      comment: null
+      comment: nil
     example:
       name: Fred
       comment: # Providing a value here is not allowed.
 ```
 
-The following example shows how to represent nullable properties using a union:
+The following example shows how to represent nilable properties using a union:
 ​
 ```yaml
 types:
-  NullValue:
+  NilValue:
     type: object
     properties:
       name:
-      comment: null | string # equivalent to ->
+      comment: nil | string # equivalent to ->
                              # comment: string?
     example:
       name: Fred
       comment: # Providing a value or not providing a value here is allowed.
 ```
 
-Declaring the type of a property to be `null` represents the lack of a value in a type instance. In a RAML context that requires *values* of type `null` (vs just type declarations), the usual YAML `null` is used, e.g. when the type is `null | number` you may use `enum: [ 1, 2, ~ ]` or more explicitly/verbosely `enum: [ 1, 2, !!null "" ]`; in non-inline notation you can just omit the value completely, of course.
+Declaring the type of a property to be `nil` represents the lack of a value in a type instance. In a RAML context that requires *values* of type `nil` (vs just type declarations), the usual YAML `null` is used, e.g. when the type is `nil | number` you may use `enum: [ 1, 2, ~ ]` or more explicitly/verbosely `enum: [ 1, 2, !!null "" ]`; in non-inline notation you can just omit the value completely, of course.
 
 #### Union Type
 
@@ -2821,8 +2821,8 @@ The following example shows various annotation type declarations and the applica
 title: Illustrating annotations
 mediaType: application/json
 annotationTypes:
-  deprecated: null
-  experimental: null | string
+  deprecated: nil
+  experimental: nil | string
   feedbackRequested: string?
   testHarness:
     type: string # This line can be omitted as it's the default type


### PR DESCRIPTION
according to the decision in #514; the `null` type created problems with the YAML spec and having to modify the YAML parser to support that type. To be more close to the spec, we decided to change `null` to `nil`. that avoids anyone to modify the YAML parser.