### PR TITLE
Refine trailing slash behavior.

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -317,13 +317,12 @@ baseUri: http://api.test.com/common/
   /groups:
 ```
 
-In the following, more complicated example with consecutive slashes in multiple places, only trailing slashes in the base URI are collapsed, leading to these absolute paths to resources: `//api.test.com//common/`, `//api.test.com//common//users/`, and `//api.test.com//common//users//groups//`.
+Similarly, when a path component ends in one or more slashes (`/`), those trailing slashes are omitted when appended to subsequent path components. For example, in the following snippet, the absolute paths for the resources are `http://api.test.com/common/users/`, and `http://api.test.com/common/users/groups/`.
 
 ```yaml
-baseUri: //api.test.com//common//
-/:
-  /users/:
-    /groups//:
+baseUri: http://api.test.com/common/
+/users/:
+  /groups/:
 ```
 
 ### Protocols


### PR DESCRIPTION
This proposal does two things:

* Modify the wording of how trailing slashes are treated, in order to allow for resources that (1) have a trailing slash and (2) also have a child resource.
* Changes the example to a more conventional example case. (the existing example with multiple consecutive slashes within the URL did not present a typical real-world case, and is more confusing than helpful.)

Without this change it is impossible to represent the `http://api.test.com/common/users/` and `http://api.test.com/common/users/groups/` resources as desired, because the absolute path resolution for the groups resource would result in `http://api.test.com/common/users//groups/`.

If required I could present this pull request *without* also cleaning up the example to be more conventional, but I think it would be less clear.