### PR TITLE
Add baseUri to example

### DIFF
--- a/versions/raml-08/raml-08.md
+++ b/versions/raml-08/raml-08.md
@@ -536,6 +536,7 @@ If a URI parameter in a resource's relative URI is not explicitly described in a
 #%RAML 0.8
 title: Flat Filesystem API
 version: v1
+baseUri: https://api.github.com
 /files:
   description: A collection of all files
   /folder_{folderId}-file_{fileId}:
@@ -548,6 +549,7 @@ A special uriParameter, *mediaTypeExtension*, is a reserved parameter. It may be
 #%RAML 0.8
 title: API Using media type in the URL
 version: v1
+baseUri: https://api.github.com
 /users{mediaTypeExtension}:
   uriParameters:
     mediaTypeExtension:


### PR DESCRIPTION
In section https://github.com/raml-org/raml-spec/blob/master/versions/raml-08/raml-08.md#template-uris-and-uri-parameters, there are two example missing the required key baseUri

I understand it claims in the previous section that baseUri is 
> Optional during development; Required after implementation

As I am building a parser for raml and extracting test case according to this spec and found this example is not able to pass the previous validation on baseUri because it is missing.
Personally, I think it would be nice to have the baseUri section added to those two examples.