### PR TITLE
Update pattern property example

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -706,8 +706,9 @@ This pattern property restricts any additional properties whose keys start with 
 Person:
   name: "John"
   age: 35
+  note1: "US" # valid
   note2: 123 # not valid as it is not a string
-  note1: "US" # valid as it does not match the pattern
+  note: 123 # valid as it does not match the pattern
 ```
 
 To force all additional properties to be strings, regardless of their keys, use:


### PR DESCRIPTION
In the current example of pattern property specification `note1` property is described as valid as not matching the pattern. The property is valid however for the different reason. It is valid as it is a string. This pull request provides a correction for the comment and adds an example of another property not matching the pattern.