### PR TITLE
Fix 'Conflicting Properties'

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -3570,20 +3570,9 @@ Exceptions:
 
 **Conflicting Properties**
 
-Conflicting properties are the properties that cannot coexist in the same Object.
+Conflicting properties are the properties that cannot coexist in the same _Object_. They are said to be mutually exclusive. 
 
-In the following example, both "type" and "properties" _Properties_ can coexist, but the "enum" _Property_ cannot coexist with both "type" and "properties".
-
-<pre style="background-color:#111;">
-<font color="white">color:</font>
-<font color="#44ff44">  type:</font> <font color="white">object</font>
-<font color="#44ff44">  properties:</font>
-<font color="white">    name: string</font>
-<font color="#ff4444">  enum:</font>
-<font color="white">   - White</font>
-<font color="white">   - Black</font>
-<font color="white">   - Colored</font>
-</pre>
+For example, the "queryString" and "queryParameters" properties of a method object are _Conflicting Properties_.
 
 **Ignored properties**
 


### PR DESCRIPTION
There is currently an inaccurate illustration of the "Conflicting Properties" terminology in the RAML 1.0 Spec. This PR fixes that.

For the record, here’s a timeline of what happened: 
- back in RAML 0.8, the `enum` property only applied to properties of type 'string'
- the “Conflicting Properties” section [1] was submitted as part of RAML 1.0 RC1
- the `enum` property description was then under the “Scalar Types” section [2]
- that description [3] then seem to indicate that `type: file` and `enum` were mutually exclusive
- between RAML 1.0 RC1 and GA, a decision was made that `enum` should apply to any type [4] and therefor to move the description of `enum` to reflect that [5]

[1] https://github.com/raml-org/raml-spec/blob/f2ff46cdf2b0fc9dc437ec541afc27194553d6e7/versions/raml-10/raml-10.md#conflicting-properties
[2] https://github.com/raml-org/raml-spec/blob/f2ff46cdf2b0fc9dc437ec541afc27194553d6e7/versions/raml-10/raml-10.md#scalar-types
[3] “All types, except the file type, can have an additional enum facet.”
[4] https://github.com/raml-org/raml-spec/issues/501
[5] https://github.com/raml-org/raml-spec/pull/502