### PR TITLE
Fix invalid resourceTypes examples 

### DIFF
--- a/versions/raml-10/raml-10.md
+++ b/versions/raml-10/raml-10.md
@@ -3156,7 +3156,7 @@ traits: !include patterns/traits.raml
 
 collection:
   get:
-    is: paged
+    is: [ paged ]
   post:
 member:
   get:
@@ -3185,7 +3185,7 @@ version: v1
 resourceTypes:
   collection:
     get:
-      is: paged
+      is: [ paged ]
     post:
   member:
     get:


### PR DESCRIPTION
Those two examples showcase the use of the `is` node in the context of applying `resourceTypes`. However, the value of `is` in those examples is a string. It should be `an array of any number of elements` as [per the Spec](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#applying-resource-types-and-traits). This PR fixes that.